### PR TITLE
adding template for reporting issue on landing-page

### DIFF
--- a/.github/ISSUE_TEMPLATE/application.yml
+++ b/.github/ISSUE_TEMPLATE/application.yml
@@ -1,6 +1,6 @@
 name: Ecosystem Project application
 description: Apply to be a member of the PyTorch Ecosystem landscape
-title: "[Ecosystem]<Project Name>"
+title: "[Ecosystem] <Project Name>"
 labels: [New]
 body:
 - type: markdown

--- a/.github/ISSUE_TEMPLATE/report_issue.yml
+++ b/.github/ISSUE_TEMPLATE/report_issue.yml
@@ -1,0 +1,43 @@
+name: Report an issue
+description: Notify us about an issue on PyTorch Ecosystem landscape
+title: "[Issue] <Project Name>"
+labels: [bug]
+body:
+- type: markdown
+  attributes:
+    value: |
+     Thanks for filling out a PyTorch Ecosystem Project issue.
+     The PyTorch ecosystem consists of projects, tools, and libraries from a broad set of researchers in academia and industry, application developers, and ML engineers.
+     The goal of the ecosystem is to support, accelerate, and aid user development with PyTorch. 
+     We appreciate your feedback and will work to address any issues you report.
+- type: input
+  attributes:
+    label: Contact emails
+    description: |
+      Provide the email address(es) of individuals who can provide more details if needed.
+      If more than one email is provided, please comma separate them.
+    placeholder: Comma-separate multiple emails here
+  validations:
+    required: true
+- type: input
+  attributes:
+    label: Project link
+    description: Provide a link to the project on the PyTorch Ecosystem landscape.
+    placeholder: https://landscape.pytorch.org/?item=...
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Issue description
+    description: |
+      Provide a brief description of the issue.
+      If beneficial, please include a screenshot of the issue.
+    placeholder: Describe the problem with the project on the landscape.
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Additional information
+    description: Any additional information you would like the PyTorch TAC to consider when evaluating this issue?
+  validations:
+    required: false


### PR DESCRIPTION
I noticed that the Lightning page has an incorrect title and wanted to report it. However, while looking for a way to submit an issue, I found that the only available template is for applications, which isn’t a suitable format for this type of report.

To improve issue reporting, I propose one of the following:
	1.	Adding an additional issue template for general reports.
	2.	Including a contact email or another communication method in the issue configuration.

This would make it easier for users to report issues effectively. Let me know your thoughts 🐰 